### PR TITLE
Add temporary xpyriment-gst backend setting

### DIFF
--- a/openexp/backend_info.py
+++ b/openexp/backend_info.py
@@ -30,7 +30,7 @@ legacy = {
 	"synth" : "legacy", \
 	"icon" : "os-pygame"
 	}
-	
+
 opengl = {
 	"description" : "uses PyGame and OpenGL", \
 	"canvas" : "opengl", \
@@ -38,8 +38,8 @@ opengl = {
 	"mouse" : "legacy", \
 	"sampler" : "legacy", \
 	"synth" : "legacy", \
-	"icon" : "os-pygame"	
-	}	
+	"icon" : "os-pygame"
+	}
 
 psycho = {
 	"description" : "uses PsychoPy, powerful stimulus generation", \
@@ -48,9 +48,9 @@ psycho = {
 	"mouse" : "psycho", \
 	"sampler" : "legacy", \
 	"synth" : "legacy", \
-	"icon" : "os-psychopy"	
+	"icon" : "os-psychopy"
 	}
-	
+
 xpyriment = {
 	"description" : "uses Expyriment", \
 	"canvas" : "xpyriment", \
@@ -59,8 +59,18 @@ xpyriment = {
 	"sampler" : "legacy", \
 	"synth" : "legacy", \
 	"icon" : "os-expyriment"
-	}	
-	
+	}
+
+xpyriment_gst = {
+	"description" : "uses Expyriment with Gstreamer for sound", \
+	"canvas" : "xpyriment", \
+	"keyboard" : "legacy", \
+	"mouse" : "xpyriment", \
+	"sampler" : "gstreamer", \
+	"synth" : "gstreamer", \
+	"icon" : "os-expyriment"
+	}
+
 droid = {
 	"description" : "for Android devices", \
 	"canvas" : "droid", \
@@ -69,11 +79,12 @@ droid = {
 	"sampler" : "legacy", \
 	"synth" : "droid", \
 	"icon" : "os-android"
-	}	
-	
+	}
+
 backend_list = {}
 backend_list["legacy"] = legacy
 backend_list["xpyriment"] = xpyriment
+backend_list["xpyriment-gst"] = xpyriment_gst
 backend_list["droid"] = droid
 # Do not add psychopy to the list on 64-bit OS X as this doesn't work
 if not (platform.system() == 'Darwin' and sys.maxsize > 2**32):
@@ -84,20 +95,20 @@ def match(experiment):
 	"""
 	Returns the name of the backend that is currently used by
 	the experiment or "custom" if no matching backend is found.
-	
+
 	Arguments:
 	experiment -- an instance of libopensesame.experiment.experiment
-	
+
 	Returns:
 	The name of the backend or "custom" if no matching backend is found
 	"""
-	
-	for name in backend_list:	
-		backend = backend_list[name]	
+
+	for name in backend_list:
+		backend = backend_list[name]
 		if experiment.canvas_backend == backend["canvas"] and \
 			experiment.keyboard_backend == backend["keyboard"] and \
 			experiment.mouse_backend == backend["mouse"] and \
 			experiment.sampler_backend == backend["sampler"] and \
-			experiment.synth_backend == backend["synth"]:			
+			experiment.synth_backend == backend["synth"]:
 			return name
 	return "custom"


### PR DESCRIPTION
Hi Daniel,

I played around with it for a bit and added some (temporary) info to the back-end settings so that you can easily select the gstreamer back-ends from the menu.

So far, it seems to work fairly well on Windows 7, but on (K)ubuntu 13.10 it doesn't work reliably at all. Basically, sound playback is generally mute and OpenSesame freezes when it waits until sound playback is finished. Occasionally I get a beep, but usually there's nothing. Any idea what the problem could be? Have you tested on Linux yet?

Cheers,
Sebastiaan
